### PR TITLE
Switch from unsupported Redash queries/alerts to new versions

### DIFF
--- a/terraform/job.tf
+++ b/terraform/job.tf
@@ -9,7 +9,7 @@ resource "databricks_job" "this" {
       sql_task {
         warehouse_id = local.warehouse_id
         alert {
-          alert_id = databricks_sql_alert.alert[task.value].id
+          alert_id = databricks_alert.alert[task.value].id
 
           dynamic "subscriptions" {
             for_each = var.alert_emails

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     databricks = {
-      source = "databricks/databricks"
+      source  = "databricks/databricks"
+      version = ">= 1.59.0, < 2.0.0"
     }
   }
 }


### PR DESCRIPTION
Use `databricks_query` instead of `databricks_sql_query` and `databricks_alert` instead of `databricks_sql_alert`.